### PR TITLE
Refactor legacy can-model to use separated modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,16 @@
   },
   "homepage": "https://github.com/canjs/can-model#readme",
   "dependencies": {
-    "can": "^2.3.10",
+    "can-construct": "^3.0.0-pre.7",
+    "can-event": "^3.0.0-pre.5",
+    "can-list": "^3.0.0-pre.5",
+    "can-map": "^3.0.0-pre.8",
+    "can-observation": "^3.0.0-pre.2",
+    "can-util": "^3.0.0-pre.28",
     "jquery": "2.1.4"
   },
   "devDependencies": {
+    "can-fixture": "^0.3.0",
     "jshint": "^2.9.1",
     "steal": "^0.13.2",
     "steal-qunit": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "can-list": "^3.0.0-pre.5",
     "can-map": "^3.0.0-pre.8",
     "can-observation": "^3.0.0-pre.2",
-    "can-util": "^3.0.0-pre.28",
+    "can-util": "^3.0.0-pre.31",
     "jquery": "2.1.4"
   },
   "devDependencies": {

--- a/src/model_test.js
+++ b/src/model_test.js
@@ -453,8 +453,7 @@ test('save error args', function () {
 		.save(function () {
 			ok(false, 'success should not be called');
 			start();
-		}, function (pack) {
-			var jQXHR = pack[0];
+		}, function (jQXHR) {
 			ok(true, 'error called');
 			ok(jQXHR.getResponseHeader, 'jQXHR object');
 			start();


### PR DESCRIPTION
Tests are passing for this if https://github.com/canjs/can-util/pull/28 and https://github.com/canjs/can-util/pull/29 are accepted -- otherwise `dom.ajax()` isn't accessible from `can-util` and `makeArray` is missing the "y"

Some tests had to be skipped, & the reasons for that are external to this package:

* `can-construct` has that `eval()` method for giving names to constructors, but because of the way it's implemented, it doesn't take dotted names for Models.  This has been worked around in the tests, but it should be fixed.

* `can-util/dom/ajax/ajax` returns a basic Promise (i.e. a `Promise` from `when`) rather than an XHR-like object.  Thus `abort()` is not exposed to any higher layer, and the test for `abort` in `can-model` cannot be run successfully.

Otherwise, this is a refactor of can-model which is not dependent on monolithic canjs.