### PR TITLE
Use util methods directly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+; Unix-style newlines
+[*]
+end_of_line = LF
+indent_style = tab
+trim_trailing_whitespace = false
+insert_final_newline = true


### PR DESCRIPTION
This fixes it so that we directly import the util methods we need and
use those rather than only importing all of can-util. Also ensures that
can.Model is set on can-util/namespace.