### PR TITLE
Add @package to the docs

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -5,6 +5,7 @@
 @download can/model
 @test src/test/test.html
 @link ../docco/model/model.html docco
+@package ../package.json
 
 @signature `Model([name,] staticProperties, instanceProperties)`
 Create a Model constructor. (See [can-construct] for more details on this syntax.)


### PR DESCRIPTION
This will make the npm and GitHub buttons appear in the rendered docs.