### PR TITLE
allows jquery 2.x deferred

### DIFF
--- a/src/can-model.js
+++ b/src/can-model.js
@@ -449,7 +449,12 @@ ns.Model = Map.extend({
 						var def = newMethod.apply(this, arguments);
 						// ...and clean up the store.
 						var then = def.then(clean);
-						def.catch(clean);
+						// jquery 2.x only has .fail
+						if (def.catch) {
+							def.catch(clean);
+						} else {
+							def.fail(clean);
+						}
 						// Pass along `abort` so you can still abort the AJAX call.
 						then.abort = def.abort;
 

--- a/src/model_test.js
+++ b/src/model_test.js
@@ -1711,3 +1711,25 @@ test("Models should be removed from store when instance.removeAttr('id') is call
 	ok(typeof Task.store[t1.id] === "undefined", "Model should be removed from store when `id` is removed");
 
 });
+
+test("uses def.fail if model uses jquery deferred", function() {
+	var Thing = Model.extend('Thing', {
+		findOne: function (data, success, error) {
+			// simulate a jquery@2 deferred that is not promise-compliant
+			var dfd = {
+				then: function() {
+					return dfd;
+				},
+				fail: function(cb) {
+					cb();
+				}
+			};
+			return dfd;
+		},
+		_clean: function () {
+			ok(true, '_clean should be called');
+		}
+	}, {});
+
+	Thing.findOne({});
+});


### PR DESCRIPTION
Originally thought the issue was related to using jquery deferred, but it's only a problem in jQuery 2.x.  jQuery 3.x has promise compliant deferreds, and does not have this same issue. Better solution is to upgrade jQuery, or use native promises, but this might also help someone else that upgrades from CanJS 2.3 -> CanJS 4.x without having to immediately upgrade their jQuery version.

closes #41 