### PR TITLE
Add ajax custom function

### DIFF
--- a/src/can-model.js
+++ b/src/can-model.js
@@ -87,7 +87,7 @@ var pipe = function (def, thisArg, func) {
 		// Substitute in data for any templated parts of the URL.
 		params.url = replaceWith(params.url, params.data, urlParamEncoder, true);
 
-		return canAjax(assign({
+		return (this.ajax || canAjax)(assign({
 			type: type.toUpperCase() || 'POST',
 			dataType: dataType || 'json',
 			success: success,
@@ -334,7 +334,7 @@ var pipe = function (def, thisArg, func) {
 				data;
 
 			// Make the AJAX call with the URL, data, and type indicated by the proper `ajaxMethod` above.
-			return ajax(str || this[ajaxMethod.url || "_url"], data, ajaxMethod.type || "get");
+			return ajax.call(this, str || this[ajaxMethod.url || "_url"], data, ajaxMethod.type || "get");
 		};
 	},
 	// ## createURLFromResource

--- a/src/model_test.js
+++ b/src/model_test.js
@@ -1733,3 +1733,20 @@ test("uses def.fail if model uses jquery deferred", function() {
 
 	Thing.findOne({});
 });
+
+test("set custom ajax function (#62)", function(){
+	fixture('GET /todos', function () {
+		return [{id: 1}];
+	});
+	var Todo = Model.extend({
+		findAll: "GET /todos",
+		ajax: function(settings) {
+			QUnit.ok(true,"custom ajax called");
+			QUnit.equal( settings.url , "/todos", "url looks right");
+			// Return the promise otherwise it throws an error
+			// "Cannot read property 'then' of undefined"
+			return Promise.resolve();
+		}
+	}, {});
+	Todo.findAll();
+});


### PR DESCRIPTION
This adds to ability to set a custom Ajax function like the following:

```js
var Todo = Model.extend({
   ...
   ajax: function(settings) {}
   ...
}, {});
```